### PR TITLE
Add MulticastLock for Android

### DIFF
--- a/nsd/README.md
+++ b/nsd/README.md
@@ -104,3 +104,12 @@ enableLogging(LogTopic.calls);
 ```
 
 will log all calls to the native side (and their callbacks), which often yields useful information.
+
+
+## For Android
+
+Add the permission to the manifest:
+```Xml
+<uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+```
+

--- a/nsd/example/android/app/src/debug/AndroidManifest.xml
+++ b/nsd/example/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,5 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
 </manifest>

--- a/nsd/example/android/app/src/profile/AndroidManifest.xml
+++ b/nsd/example/android/app/src/profile/AndroidManifest.xml
@@ -4,4 +4,5 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
 </manifest>


### PR DESCRIPTION
Thank you for the wonderful plugin!
It works fine on most Android devices, but I couldn't explore any services on my Google Pixel 4a (Android 11).

I've investigated this issue, but it seems that you may need to create a "MulticastLock".
It's a guess, but I think that the power saving function peculiar to the terminal is probably working.
https://pzoleeblogen.wordpress.com/2014/03/04/android-udp-broadcast-message-is-not-received/
https://developer.android.com/reference/android/net/wifi/WifiManager.MulticastLock

After adding this implementation, I was able to successfully search for services on the above terminals.
Please let us know if you need further corrections or explanations.
Sorry for my poor English. Thanking you in advance.