### PR TITLE
nsd_android: Fix overload resolution ambiguity

### DIFF
--- a/nsd_android/android/src/main/kotlin/com/haberey/flutter/nsd_android/Serialization.kt
+++ b/nsd_android/android/src/main/kotlin/com/haberey/flutter/nsd_android/Serialization.kt
@@ -87,7 +87,7 @@ internal fun NsdServiceInfo.setAttributesFromTxt(flutterTxt: Map<String, ByteArr
             val value = it.value
 
             if (value == null) {
-                setAttribute(key, null)
+                setAttribute(key, null as String?)
             } else {
                 assertValidUtf8(key, value)
                 setAttribute(key, value.toString(Charsets.UTF_8))


### PR DESCRIPTION
Compiling for android fails. This PR fixes that.

```
$ flutter build apk

e: ~/.pub-cache/hosted/pub.dev/nsd_android-2.0.0/android/src/main/kotlin/com/haberey/flutter/nsd_android/Serialization.kt: (90, 17): Overload resolution ambiguity: 
public open fun setAttribute(key: String!, value: ByteArray!): Unit defined in android.net.nsd.NsdServiceInfo
public open fun setAttribute(key: String!, value: String!): Unit defined in android.net.nsd.NsdServiceInfo

FAILURE: Build failed with an exception.
```