### PR TITLE
Use native service address

### DIFF
--- a/nsd/pubspec.yaml
+++ b/nsd/pubspec.yaml
@@ -13,24 +13,24 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # production
-  nsd_android: ^2.0.0
-  nsd_ios: ^2.0.0
-  nsd_macos: ^2.0.0
-  nsd_platform_interface: ^2.0.0
-  nsd_windows: ^3.0.0
+  # development
+  nsd_android:
+    path: ../nsd_android
+  nsd_ios:
+    path: ../nsd_ios
+  nsd_macos:
+    path: ../nsd_macos
+  nsd_windows:
+    path: ../nsd_windows
+  nsd_platform_interface:
+    path: ../nsd_platform_interface
 
-#  # development
-#  nsd_android:
-#    path: ../nsd_android
-#  nsd_ios:
-#    path: ../nsd_ios
-#  nsd_macos:
-#    path: ../nsd_macos
-#  nsd_windows:
-#    path: ../nsd_windows
-#  nsd_platform_interface:
-#    path: ../nsd_platform_interface
+  # production
+#  nsd_android: ^2.0.0
+#  nsd_ios: ^2.0.0
+#  nsd_macos: ^2.0.0
+#  nsd_platform_interface: ^2.0.0
+#  nsd_windows: ^3.0.0
 
 dev_dependencies:
   flutter_lints: ^3.0.1

--- a/nsd_android/android/src/main/kotlin/com/haberey/flutter/nsd_android/Serialization.kt
+++ b/nsd_android/android/src/main/kotlin/com/haberey/flutter/nsd_android/Serialization.kt
@@ -12,6 +12,7 @@ private enum class Key(val serializeKey: String) {
     SERVICE_TYPE("service.type"),
     SERVICE_HOST("service.host"),
     SERVICE_PORT("service.port"),
+    SERVICE_ADDRESSES("service.addresses"),
     SERVICE_TXT("service.txt"),
     ERROR_CAUSE("error.cause"),
     ERROR_MESSAGE("error.message"),
@@ -110,6 +111,7 @@ internal fun serializeServiceInfo(nsdServiceInfo: NsdServiceInfo): Map<String, A
         Key.SERVICE_NAME.serializeKey to nsdServiceInfo.serviceName,
         Key.SERVICE_TYPE.serializeKey to removeLeadingAndTrailingDots(serviceType = nsdServiceInfo.serviceType),
         Key.SERVICE_HOST.serializeKey to nsdServiceInfo.host?.canonicalHostName,
+        Key.SERVICE_ADDRESSES.serializeKey to nsdServiceInfo.host?.hostAddress,
         Key.SERVICE_PORT.serializeKey to if (nsdServiceInfo.port == 0) null else nsdServiceInfo.port,
         Key.SERVICE_TXT.serializeKey to nsdServiceInfo.attributes,
     )

--- a/nsd_android/pubspec.yaml
+++ b/nsd_android/pubspec.yaml
@@ -1,8 +1,6 @@
 name: nsd_android
 description: Flutter network service discovery plugin (Android submodule - will be installed with the parent plugin).
 version: 2.0.0
-repository: https://github.com/sebastianhaberey/nsd/tree/main/nsd_android
-issue_tracker: https://github.com/sebastianhaberey/nsd/issues
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/nsd_platform_interface/lib/src/method_channel_nsd_platform.dart
+++ b/nsd_platform_interface/lib/src/method_channel_nsd_platform.dart
@@ -61,7 +61,7 @@ class MethodChannelNsdPlatform extends NsdPlatformInterface {
       if (autoResolve) {
         service = await resolve(service);
 
-        if (isIpLookupEnabled(ipLookupType)) {
+        if (isIpLookupEnabled(ipLookupType) && service.addresses == null) {
           service = await performIpLookup(service, ipLookupType);
         }
       }

--- a/nsd_platform_interface/lib/src/serialization.dart
+++ b/nsd_platform_interface/lib/src/serialization.dart
@@ -52,18 +52,16 @@ Service? deserializeService(dynamic arguments) {
   final host = data['service.host'] as String?;
   final port = data['service.port'] as int?;
   final txt = data['service.txt'] != null
-      ? Map<String, Uint8List?>.from(data['service.txt'])
-      : null;
+  final addresses = data['service.addresses'] as String?;
+  final txt = data['service.txt'] != null ? Map<String, Uint8List?>.from(data['service.txt']) : null;
 
-  if (name == null &&
-      type == null &&
-      host == null &&
-      port == null &&
-      txt == null) {
+  if (name == null && type == null && host == null && port == null && addresses == null && txt == null) {
     return null;
   }
 
-  return Service(name: name, type: type, host: host, port: port, txt: txt);
+  final inetAddresses = addresses != null ? [InternetAddress(addresses)] : null;
+
+  return Service(name: name, type: type, host: host, port: port, addresses: inetAddresses, txt: txt);
 }
 
 Map<String, dynamic> serializeHandle(String value) => {


### PR DESCRIPTION
Use ip-addresses of nsdServiceInfo to avoid ip lookup inside dart code. Aims to resolve a problem where two devices with the same hostname got 2 ip addresses assigned 