### PR TITLE
prefer using ip address given by android service

### DIFF
--- a/nsd_android/android/src/main/kotlin/com/haberey/flutter/nsd_android/Serialization.kt
+++ b/nsd_android/android/src/main/kotlin/com/haberey/flutter/nsd_android/Serialization.kt
@@ -12,6 +12,7 @@ private enum class Key(val serializeKey: String) {
     SERVICE_TYPE("service.type"),
     SERVICE_HOST("service.host"),
     SERVICE_PORT("service.port"),
+    SERVICE_ADDRESSES("service.addresses"),
     SERVICE_TXT("service.txt"),
     ERROR_CAUSE("error.cause"),
     ERROR_MESSAGE("error.message"),
@@ -110,6 +111,7 @@ internal fun serializeServiceInfo(nsdServiceInfo: NsdServiceInfo): Map<String, A
         Key.SERVICE_NAME.serializeKey to nsdServiceInfo.serviceName,
         Key.SERVICE_TYPE.serializeKey to removeLeadingAndTrailingDots(serviceType = nsdServiceInfo.serviceType),
         Key.SERVICE_HOST.serializeKey to nsdServiceInfo.host?.canonicalHostName,
+        Key.SERVICE_ADDRESSES.serializeKey to nsdServiceInfo.host?.hostAddress,
         Key.SERVICE_PORT.serializeKey to if (nsdServiceInfo.port == 0) null else nsdServiceInfo.port,
         Key.SERVICE_TXT.serializeKey to nsdServiceInfo.attributes,
     )

--- a/nsd_platform_interface/lib/src/method_channel_nsd_platform.dart
+++ b/nsd_platform_interface/lib/src/method_channel_nsd_platform.dart
@@ -61,7 +61,7 @@ class MethodChannelNsdPlatform extends NsdPlatformInterface {
       if (autoResolve) {
         service = await resolve(service);
 
-        if (isIpLookupEnabled(ipLookupType)) {
+        if (isIpLookupEnabled(ipLookupType) && service.addresses == null) {
           service = await performIpLookup(service, ipLookupType);
         }
       }

--- a/nsd_platform_interface/lib/src/serialization.dart
+++ b/nsd_platform_interface/lib/src/serialization.dart
@@ -51,7 +51,6 @@ Service? deserializeService(dynamic arguments) {
   final type = data['service.type'] as String?;
   final host = data['service.host'] as String?;
   final port = data['service.port'] as int?;
-  final txt = data['service.txt'] != null
   final addresses = data['service.addresses'] as String?;
   final txt = data['service.txt'] != null ? Map<String, Uint8List?>.from(data['service.txt']) : null;
 

--- a/nsd_platform_interface/lib/src/serialization.dart
+++ b/nsd_platform_interface/lib/src/serialization.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'nsd_platform_interface.dart';

--- a/nsd_platform_interface/lib/src/serialization.dart
+++ b/nsd_platform_interface/lib/src/serialization.dart
@@ -52,18 +52,21 @@ Service? deserializeService(dynamic arguments) {
   final host = data['service.host'] as String?;
   final port = data['service.port'] as int?;
   final txt = data['service.txt'] != null
-      ? Map<String, Uint8List?>.from(data['service.txt'])
-      : null;
+  final addresses = data['service.addresses'] as String?;
+  final txt = data['service.txt'] != null ? Map<String, Uint8List?>.from(data['service.txt']) : null;
 
-  if (name == null &&
-      type == null &&
-      host == null &&
-      port == null &&
+  if (name == null && 
+      type == null && 
+      host == null && 
+      port == null && 
+      addresses == null && 
       txt == null) {
     return null;
   }
 
-  return Service(name: name, type: type, host: host, port: port, txt: txt);
+  final inetAddresses = addresses != null ? [InternetAddress(addresses)] : null;
+
+  return Service(name: name, type: type, host: host, port: port, addresses: inetAddresses, txt: txt);
 }
 
 Map<String, dynamic> serializeHandle(String value) => {


### PR DESCRIPTION
In our project we were facing an issue where we had several devices with the same hostname within one network. Doing the ip lookup using the hostname resulted in a set of ip addresses for each device and we were not able to identify the correct ip for each device. 

We solved this issue by applying the following changes.