### PR TITLE
fix: Add missing namespace declaration in nsd_android module

### DIFF
--- a/nsd_android/android/build.gradle
+++ b/nsd_android/android/build.gradle
@@ -1,4 +1,3 @@
-group 'com.haberey.flutter.nsd_android'
 version '1.0-SNAPSHOT'
 
 buildscript {
@@ -26,6 +25,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+    namespace 'com.haberey.flutter.nsd_android' 
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/nsd_android/android/build.gradle
+++ b/nsd_android/android/build.gradle
@@ -1,3 +1,4 @@
+group 'com.haberey.flutter.nsd_android'
 version '1.0-SNAPSHOT'
 
 buildscript {


### PR DESCRIPTION
fix(nsd_android): add missing namespace declaration in build.gradle

Closes #73