### PR TITLE
Update nsd_ios.podspec. We should not lock swift version to 5.0

### DIFF
--- a/nsd_ios/ios/nsd_ios.podspec
+++ b/nsd_ios/ios/nsd_ios.podspec
@@ -19,5 +19,4 @@ A new flutter plugin project.
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
-  s.swift_version = '5.0'
 end


### PR DESCRIPTION
We have a add-to-app project, and swift version is lower than 5.0. When compile an error happen.

```
Undefined symbol: _OBJC_CLASS_$_NsdlosPlugin
Linker command failed with exit code 1 (use -v to see
invocation)
```

This PR is to remove swift version limitation.